### PR TITLE
feat(cmd): add context handling for VM operations to manage interrupts

### DIFF
--- a/go/.golangci.yml
+++ b/go/.golangci.yml
@@ -1,19 +1,11 @@
 # TODO: Add more linters
 # https://gist.githubusercontent.com/maratori/47a4d00457a92aa426dbd48a18776322/raw/43d6de07ca238a3994737171bd3fe2cd2b769bc0/.golangci.yml
 
-linters-settings:
-  govet:
-    enable-all: true
-    settings:
-      shadow:
-        strict: true
-  gocyclo:
-    min-complexity: 30
-  misspell:
-    locale: US
+version: "2"
 
 linters:
-  disable-all: true
+  # disable-all: true
+  default: none
   enable:
     - goimports
     - unused
@@ -25,3 +17,14 @@ linters:
     - misspell
     - staticcheck
     - whitespace
+
+  settings:
+    govet:
+      enable-all: true
+      settings:
+        shadow:
+          strict: true
+    gocyclo:
+      min-complexity: 30
+    misspell:
+      locale: US

--- a/go/.golangci.yml
+++ b/go/.golangci.yml
@@ -7,12 +7,10 @@ linters:
   # disable-all: true
   default: none
   enable:
-    - goimports
     - unused
     - errcheck
     - gocognit
     - gocyclo
-    - gofmt
     - govet
     - misspell
     - staticcheck
@@ -28,3 +26,8 @@ linters:
       min-complexity: 30
     misspell:
       locale: US
+
+formatters:
+  enable:
+    - goimports
+    - gofmt

--- a/go/cmd/describe.go
+++ b/go/cmd/describe.go
@@ -4,9 +4,10 @@ Copyright © 2025 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/list"
@@ -48,7 +49,8 @@ Example:
 		}
 		// Describe the instance
 		// Update VMs info, such as status and schedule policy
-		ctx := context.Background()
+		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
 		if err = gce.UpdateInstancesInfo(ctx, []*config.VM{vm}); err != nil {
 			utils.ErrorReport(fmt.Sprintf("Failed to update VMs info: %v\n", err))
 			os.Exit(1)

--- a/go/cmd/list.go
+++ b/go/cmd/list.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/table"
@@ -38,7 +39,8 @@ Example:
 		log.Logger.Debug(fmt.Sprintf("Config: %+v", cnf))
 
 		// Update VMs info, such as status and schedule policy
-		ctx := context.Background()
+		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
 		if err = gce.UpdateInstancesInfo(ctx, cnf.VMs); err != nil {
 			utils.ErrorReport(fmt.Sprintf("Failed to update VMs info: %v\n", err))
 			os.Exit(1)

--- a/go/cmd/off.go
+++ b/go/cmd/off.go
@@ -6,6 +6,8 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/haru-256/gcectl/pkg/config"
 	"github.com/haru-256/gcectl/pkg/gce"
@@ -46,7 +48,9 @@ Example:
 		}
 
 		// Turn off the instance
-		if err = gce.OffVM(vm); err != nil {
+		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+		if err = gce.OffVM(ctx, vm); err != nil {
 			utils.ErrorReport(fmt.Sprintf("Failed to turn off the instance: %v\n", err))
 			os.Exit(1)
 		}

--- a/go/cmd/on.go
+++ b/go/cmd/on.go
@@ -6,6 +6,8 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/haru-256/gcectl/pkg/config"
 	"github.com/haru-256/gcectl/pkg/gce"
@@ -45,7 +47,9 @@ Example:
 		}
 
 		// Turn on the instance
-		if err = gce.OnVM(vm); err != nil {
+		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+		if err = gce.OnVM(ctx, vm); err != nil {
 			utils.ErrorReport(fmt.Sprintf("Failed to turn on the instance: %v\n", err))
 			os.Exit(1)
 		}

--- a/go/cmd/set/machine_type.go
+++ b/go/cmd/set/machine_type.go
@@ -3,6 +3,8 @@ package set
 import (
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/haru-256/gcectl/pkg/config"
 	"github.com/haru-256/gcectl/pkg/gce"
@@ -44,8 +46,10 @@ Example:
 			utils.ErrorReport(fmt.Sprintf("VM %s not found", vmName))
 			os.Exit(1)
 		}
-		// Implement your logic here
-		if err = gce.SetMachineType(vm, machineType); err != nil {
+
+		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+		if err = gce.SetMachineType(ctx, vm, machineType); err != nil {
 			utils.ErrorReport(fmt.Sprintf("Failed to set machine-type: %v\n", err))
 			os.Exit(1)
 		}

--- a/go/cmd/set/schedule.go
+++ b/go/cmd/set/schedule.go
@@ -3,6 +3,8 @@ package set
 import (
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/haru-256/gcectl/pkg/config"
 	"github.com/haru-256/gcectl/pkg/gce"
@@ -44,10 +46,12 @@ Example:
 			utils.ErrorReport(fmt.Sprintf("VM %s not found", vmName))
 			os.Exit(1)
 		}
-		// Implement your logic here
+
+		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
 		if unset {
 			log.Logger.Debug("Unset schedule-policy")
-			if err = gce.UnsetSchedulePolicy(vm, policyName); err != nil {
+			if err = gce.UnsetSchedulePolicy(ctx, vm, policyName); err != nil {
 				fmt.Printf("Failed to unset schedule-policy: %v\n", err)
 				utils.ErrorReport(fmt.Sprintf("Failed to unset schedule-policy: %v\n", err))
 				os.Exit(1)
@@ -56,7 +60,7 @@ Example:
 			}
 		} else {
 			log.Logger.Debug("Set schedule-policy")
-			if err = gce.SetSchedulePolicy(vm, policyName); err != nil {
+			if err = gce.SetSchedulePolicy(ctx, vm, policyName); err != nil {
 				utils.ErrorReport(fmt.Sprintf("Failed to set schedule-policy: %v\n", err))
 				os.Exit(1)
 			} else {

--- a/go/pkg/gce/gce.go
+++ b/go/pkg/gce/gce.go
@@ -272,9 +272,7 @@ func getProjectFromInstance(instance *computepb.Instance) (string, error) {
 	return project, nil
 }
 
-func OnVM(vm *config.VM) error {
-	ctx := context.Background()
-
+func OnVM(ctx context.Context, vm *config.VM) error {
 	// Create a new InstancesClient with authentication
 	client, err := compute.NewInstancesRESTClient(ctx)
 	if err != nil {
@@ -308,9 +306,7 @@ func OnVM(vm *config.VM) error {
 	return nil
 }
 
-func OffVM(vm *config.VM) error {
-	ctx := context.Background()
-
+func OffVM(ctx context.Context, vm *config.VM) error {
 	// Create a new InstancesClient with authentication
 	client, err := compute.NewInstancesRESTClient(ctx)
 	if err != nil {
@@ -344,8 +340,7 @@ func OffVM(vm *config.VM) error {
 	return nil
 }
 
-func SetMachineType(vm *config.VM, machineType string) error {
-	ctx := context.Background()
+func SetMachineType(ctx context.Context, vm *config.VM, machineType string) error {
 	// Create a new InstancesClient with authentication
 	client, err := compute.NewInstancesRESTClient(ctx)
 	if err != nil {
@@ -380,8 +375,7 @@ func SetMachineType(vm *config.VM, machineType string) error {
 }
 
 // SetSchedulePolicy attaches a schedule policy to a Google Compute Engine instance.
-func SetSchedulePolicy(vm *config.VM, policyName string) error {
-	ctx := context.Background()
+func SetSchedulePolicy(ctx context.Context, vm *config.VM, policyName string) error {
 	// Create a new InstancesClient with authentication
 	client, err := compute.NewInstancesRESTClient(ctx)
 	if err != nil {
@@ -430,8 +424,7 @@ func SetSchedulePolicy(vm *config.VM, policyName string) error {
 
 // UnsetSchedulePolicy detaches a schedule policy from a Google Compute Engine instance.
 // It removes the specified policy from the instance's list of attached policies.
-func UnsetSchedulePolicy(vm *config.VM, policyName string) error {
-	ctx := context.Background()
+func UnsetSchedulePolicy(ctx context.Context, vm *config.VM, policyName string) error {
 	// Create a new InstancesClient with authentication
 	client, err := compute.NewInstancesRESTClient(ctx)
 	if err != nil {

--- a/go/pkg/gce/gce_test.go
+++ b/go/pkg/gce/gce_test.go
@@ -36,10 +36,11 @@ func TestGetSchedulePolicy(t *testing.T) {
 	// Call the function
 	ctx := context.Background()
 	instance, err := getInstance(ctx, projectID, zone, instanceName)
+	assert.NoError(t, err)
 	policy, err := getSchedulePolicy(ctx, instance)
+	assert.NoError(t, err)
 
 	// Check results
-	assert.NoError(t, err)
 	assert.NotEmpty(t, policy)
 }
 


### PR DESCRIPTION
This pull request introduces signal handling for graceful termination across multiple commands in the `gcectl` CLI tool. It replaces the use of `context.Background()` with `signal.NotifyContext` to handle system signals like `SIGTERM` and `os.Interrupt`. Additionally, the corresponding functions in the `gce` package have been updated to accept a `context.Context` parameter to support this change.

### Signal Handling for Graceful Termination:
* Updated `go/cmd/describe.go`, `go/cmd/list.go`, `go/cmd/off.go`, `go/cmd/on.go`, `go/cmd/set/machine_type.go`, and `go/cmd/set/schedule.go` to use `signal.NotifyContext` for creating contexts that handle system signals (`SIGTERM` and `os.Interrupt`). This ensures proper cleanup during termination. [[1]](diffhunk://#diff-9978d99633e367bfc1fd64b62d9ae8d1439367f7c4887af5ca0e885141b5fa54L51-R53) [[2]](diffhunk://#diff-fd0a20770d762cff0b97f7f7ccfe80958b4a2e00ea8872619ba1c337a3d13926L41-R43) [[3]](diffhunk://#diff-bd8e1c06557225c4a44301852faea465968c4fd123e31c2c2d751c7f0604f4f7L49-R53) [[4]](diffhunk://#diff-ac257340e3128be9bc721960ad3a88e8a442e6de7d9c51a03e77dc76ec75a3feL48-R52) [[5]](diffhunk://#diff-f85360f57920d01cfe5b7158ec59aa43e8cef2bce5556cd9fb905ac1babb5919L47-R52) [[6]](diffhunk://#diff-685a1a93c2a75086fdf0bfb0c4033bab201b4c4beb53bdbd03ac57cc951c1ccaL47-R54) [[7]](diffhunk://#diff-685a1a93c2a75086fdf0bfb0c4033bab201b4c4beb53bdbd03ac57cc951c1ccaL59-R63)

### Refactoring of `gce` Package Functions:
* Modified `OnVM`, `OffVM`, `SetMachineType`, `SetSchedulePolicy`, and `UnsetSchedulePolicy` functions in `go/pkg/gce/gce.go` to accept a `context.Context` parameter instead of creating a new background context internally. This allows them to work seamlessly with the signal-aware contexts. [[1]](diffhunk://#diff-b51dde9c5a21a5c2ec45509d422f9aac0c1aea858afcccca2a489333257044caL275-R275) [[2]](diffhunk://#diff-b51dde9c5a21a5c2ec45509d422f9aac0c1aea858afcccca2a489333257044caL311-R309) [[3]](diffhunk://#diff-b51dde9c5a21a5c2ec45509d422f9aac0c1aea858afcccca2a489333257044caL347-R343) [[4]](diffhunk://#diff-b51dde9c5a21a5c2ec45509d422f9aac0c1aea858afcccca2a489333257044caL383-R378) [[5]](diffhunk://#diff-b51dde9c5a21a5c2ec45509d422f9aac0c1aea858afcccca2a489333257044caL433-R427)